### PR TITLE
FIX: mobileView typo, prettier readme, underline links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Discourse Stat Banner
 
-Display a banner containing stats about your Discourse site. 
+Display a banner containing stats about your Discourse site.
 
-These stats are populated from the /about page, and can be configured for 1 day, 7 day, or 30 day periods. You can display a count of topics, posts, users, likes, chat mesasges, chat channels, or chat users. 
+These stats are populated from the /about page, and can be configured for 1 day, 7 day, or 30 day periods. You can display a count of topics, posts, users, likes, chat mesasges, chat channels, or chat users.
 
-You can also set custom text, link each section, and optionally set a custom value for each stat. 
+You can also set custom text, link each section, and optionally set a custom value for each stat.
 
 ![Screenshot 2023-10-23 at 5 23 59 PM](https://github.com/discourse/discourse-stat-banner/assets/1681963/22351608-24da-473b-bcaf-83555ea63e6b)

--- a/common/common.scss
+++ b/common/common.scss
@@ -38,6 +38,9 @@
         min-width: 0;
         color: $text-color;
       }
+      a span:last-of-type {
+        text-decoration: underline;
+      }
     }
 
     span {

--- a/javascripts/discourse/components/stat-banner.gjs
+++ b/javascripts/discourse/components/stat-banner.gjs
@@ -44,7 +44,7 @@ export default class StatBanner extends Component {
   get shouldShow() {
     if (
       !settings.display_stats ||
-      (settings.hide_on_mobile && this.site.mobile_view)
+      (settings.hide_on_mobile && this.site.mobileView)
     ) {
       return false;
     }

--- a/test/acceptance/stat-banner-test.js
+++ b/test/acceptance/stat-banner-test.js
@@ -9,7 +9,7 @@ function setupDisplayStats() {
   ]);
 }
 
-acceptance("Stat Banner", function (needs) {
+acceptance("Stat Banner", function () {
   test("Banner shows based on settings", async function (assert) {
     setupDisplayStats();
 
@@ -93,21 +93,30 @@ acceptance("Stat Banner", function (needs) {
       "creates localStorage cache",
     );
   });
+});
+
+acceptance("Stat Banner - Mobile", function (needs) {
+  needs.mobileView();
+  settings.show_on = "everywhere";
 
   test("Banner appears on mobile when allowed", async function (assert) {
     setupDisplayStats();
-    needs.mobileView();
 
-    settings.show_on = "homepage";
     settings.hide_on_mobile = true;
 
     await visit("/");
 
     assert
       .dom(".stat-banner__wrapper")
-      .exists("the banner does not display on mobile");
+      .doesNotExist("the banner does not display on mobile");
+  });
+
+  test("Banner appears on mobile when allowed", async function (assert) {
+    setupDisplayStats();
 
     settings.hide_on_mobile = false;
+
+    await visit("/");
 
     assert.dom(".stat-banner__wrapper").exists("the banner displays on mobile");
   });


### PR DESCRIPTION
updates`mobile_view` to `mobileView`, prettier for readme, underline links